### PR TITLE
Replace homebrew symbolize_keys with AR version

### DIFF
--- a/hackerone-ruby.gemspec
+++ b/hackerone-ruby.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+
+  spec.add_dependency "activesupport", ">= 3.0", "< 6.0"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -1,15 +1,8 @@
+require "active_support/core_ext/hash"
 require "graphql/client"
 require "graphql/client/http"
 
 module Hackerone
-  def self.symbolize_keys(hash)
-    hash.keys.each do |key|
-      hash[key.to_sym] = hash.delete(key)
-    end
-
-    hash
-  end
-
   HTTP = GraphQL::Client::HTTP.new("https://hackerone.com/graphql")
   Schema = GraphQL::Client.load_schema(HTTP)
   Client = GraphQL::Client.new(schema: Schema, execute: HTTP)

--- a/lib/hackerone/team.rb
+++ b/lib/hackerone/team.rb
@@ -12,7 +12,7 @@ module Hackerone
     def self.find_by(handle:)
       result = ::Hackerone::Client.query TeamQuery, variables: { handle: handle }
       team_data = result.data.team.data
-      new(**::Hackerone.symbolize_keys(team_data))
+      new(**team_data.symbolize_keys)
     end
   end
 end

--- a/lib/hackerone/user.rb
+++ b/lib/hackerone/user.rb
@@ -15,7 +15,7 @@ module Hackerone
     def self.find_by(username:)
       result = ::Hackerone::Client.query UserQuery, variables: { username: username }
       user_data = result.data.user.data
-      new(**::Hackerone.symbolize_keys(user_data))
+      new(**user_data.symbolize_keys)
     end
   end
 end


### PR DESCRIPTION
Considering graphl-ruby (one of this gem's dependencies) already depends on active-support, why not bite the bullet and add it here, as well.

To be honest, I'd be happy doing `require "active_support/all"`. Any thoughts?